### PR TITLE
chore: sync shared assets

### DIFF
--- a/.github/workflows/container-build-publish.yml
+++ b/.github/workflows/container-build-publish.yml
@@ -20,18 +20,54 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Validate Quay variables/secrets
+        shell: bash
+        env:
+          QUAY_NAMESPACE: ${{ vars.QUAY_NAMESPACE }}
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          fail=0
+
+          if [ -z "${QUAY_NAMESPACE:-}" ]; then
+            echo "::error::Missing required org/repo variable: vars.QUAY_NAMESPACE"
+            fail=1
+          fi
+
+          if [ -z "${QUAY_USERNAME:-}" ]; then
+            echo "::error::Missing required secret: secrets.QUAY_USERNAME"
+            fail=1
+          fi
+
+          if [ -z "${QUAY_PASSWORD:-}" ]; then
+            echo "::error::Missing required secret: secrets.QUAY_PASSWORD"
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+
+          echo "Quay configuration present (namespace + credentials)."
+
       - name: Compute image name + tag (strip "container-" prefix)
         shell: bash
+        env:
+          QUAY_NAMESPACE: ${{ vars.QUAY_NAMESPACE }}
         run: |
           set -euo pipefail
           repo="${GITHUB_REPOSITORY#*/}"
           image_repo="${repo#container-}"
-          # Quay uses an org/user namespace. Set QUAY_NAMESPACE as a repo/org secret or use repository owner.
-          quay_ns="${QUAY_NAMESPACE:-${GITHUB_REPOSITORY_OWNER}}"
-          image_name="${REGISTRY}/${quay_ns}/${image_repo}"
+
+          # Always use vars.QUAY_NAMESPACE (validated above)
+          image_name="${REGISTRY}/${QUAY_NAMESPACE}/${image_repo}"
           tag="${{ github.event.release.tag_name }}"
+
           echo "IMAGE_NAME=${image_name}" >> "$GITHUB_ENV"
           echo "RELEASE_TAG=${tag}" >> "$GITHUB_ENV"
+
           echo "Using IMAGE_NAME=${image_name}"
           echo "Using RELEASE_TAG=${tag}"
 


### PR DESCRIPTION
Automated sync from
[lightning-it/shared-assets](https://github.com/lightning-it/shared-assets).

This PR updates:
- container tooling (linting/renovate/common docs)
- shared helper scripts (if applicable)
- container CI workflows (build/publish)

Please review and merge to keep this container repository aligned
with the central templates.