### PR TITLE
fix: constrain incompatible linux system roles update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -131,6 +131,16 @@
       "allowedVersions": "/^5\\.10\\.0$/"
     },
     {
+      "description": "Keep fedora.linux_system_roles below 1.127.x until its ansible.posix constraint supports 2.2.x",
+      "matchDepNames": [
+        "fedora.linux_system_roles"
+      ],
+      "matchDatasources": [
+        "galaxy-collection"
+      ],
+      "allowedVersions": "<1.127.0"
+    },
+    {
       "matchDatasources": [
         "galaxy-collection"
       ],


### PR DESCRIPTION
## Summary
- prevent Renovate from reopening the fedora.linux_system_roles 1.127.x update while it conflicts with ansible.posix 2.2.x
- keep the current compatible 1.126.x line until upstream collection constraints allow ansible.posix 2.2.x

## Validation
- jq empty renovate.json
- git diff --check