### PR TITLE
fix: call public OpenSSF reusable workflow

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -20,6 +20,6 @@ jobs:
       contents: read
       security-events: write
       id-token: write
-    uses: lightning-it/shared-assets-lit/.github/workflows/openssf-scorecard-reusable.yml@main
+    uses: lightning-it/.github/.github/workflows/openssf-scorecard-reusable.yml@main
     with:
       publish_results: true


### PR DESCRIPTION
Updates the generated OpenSSF Scorecard wrapper from shared-assets so public repositories call the public org reusable workflow in `lightning-it/.github`.

This keeps the reusable workflow source managed by shared-assets while making workflow_dispatch and scheduled runs usable from public repositories.
