### PR TITLE
Sync markdownlint config from shared-assets

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,7 @@
+---
+config:
+  MD004: false
+  MD012: false
+  MD013: false
+  MD032: false
+  MD060: false


### PR DESCRIPTION
## Summary
- sync shared markdownlint-cli2 config generated from shared-assets
- keep local markdown lint validation reproducible for generated docs

## Validation
- npx markdownlint-cli2 README.md RELEASE.md TESTING.md OPENSSF.md
- container-build.yml exists as a real workflow file
- Container Build README badge points to container-build.yml
- no `(none)`/placeholder container badge text detected