### PR TITLE
Add managed Container Version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-ci.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-ci.yml)
 [![Latest Release](https://img.shields.io/github/v/release/lightning-it/container-ee-wunder-ansible-ubi9?sort=semver)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/releases/latest)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/lightning-it/container-ee-wunder-ansible-ubi9/badge)](https://scorecard.dev/viewer/?uri=github.com/lightning-it/container-ee-wunder-ansible-ubi9)
+[![Container Version](https://img.shields.io/github/v/release/lightning-it/container-ee-wunder-ansible-ubi9?sort=semver&label=Container%20Version)](https://quay.io/repository/l-it/ee-wunder-ansible-ubi9)
 [![Trivy](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-trivy.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-trivy.yml)
 [![Container Build](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)


### PR DESCRIPTION
## Summary
- add managed Container Version badge from shared-assets
- keep Quay `/status` badge removed
- keep README free of container none/placeholder badge text

## Validation
- npx markdownlint-cli2 README.md RELEASE.md TESTING.md OPENSSF.md
- shared-assets release-model audit passed for the complete container repository set
- badge SVG source validated before rollout