### PR TITLE
chore: consolidate shared-assets-lit governance

### DIFF
--- a/.lit/repository.yml
+++ b/.lit/repository.yml
@@ -1,8 +1,9 @@
 ---
 schema_version: 1
-managed_by: lightning-it/shared-assets
+managed_by: lightning-it/shared-assets-lit
 repository: container-ee-wunder-ansible-ubi9
 visibility: public
+license_spdx: MIT
 repository_type: container_image
 release_type: semantic_release
 artifact_type: container_image
@@ -15,7 +16,7 @@ test_profiles:
   - release-validation
 os_matrix:
   - ubuntu-latest
-product_matrix: &id001
+product_matrix:
   - ubi9
   - podman
   - docker-buildx
@@ -35,27 +36,6 @@ readme_badges:
   - license
 workflows:
   ci: container-ci.yml
-  container_build: container-build.yml
   release: container-build-publish.yml
-  trivy: container-trivy.yml
   promote: promote-develop-to-main.yml
   backmerge: sync-main-to-develop.yml
-image_name: quay.io/l-it/ee-wunder-ansible-ubi9
-registry: quay.io
-quay_organization: l-it
-quay_repository: ee-wunder-ansible-ubi9
-version_source: semantic-release
-supported_base_images: *id001
-supported_target_platforms:
-  - linux/amd64
-  - linux/arm64
-smoke_test_command: repository default container smoke test
-healthcheck_expectation: container starts successfully where configured
-trivy_policy: CRITICAL gate with unfixed vulnerabilities ignored
-required_secrets:
-  - QUAY_USERNAME
-  - QUAY_PASSWORD
-containerfile: Dockerfile
-container_build_context: .
-trivy_required: true
-trivy_release_gate: true

--- a/OPENSSF.md
+++ b/OPENSSF.md
@@ -1,6 +1,6 @@
 # OpenSSF Readiness
 
-This repository follows the Lightning IT shared OpenSSF readiness model generated from `lightning-it/shared-assets`.
+This repository follows the Lightning IT shared OpenSSF readiness model generated from `lightning-it/shared-assets-lit`.
 
 ## Repository
 
@@ -18,7 +18,7 @@ The Scorecard badge is included in `README.md` only for public repositories wher
 
 ## Best Practices Badge
 
-Not enrolled by shared-assets automation. Enroll manually at OpenSSF Best Practices, complete the project questionnaire, then add a badge only after the project is passing.
+Not enrolled by shared-assets-lit automation. Enroll manually at OpenSSF Best Practices, complete the project questionnaire, then add a badge only after the project is passing.
 
 Do not add a passing OpenSSF Best Practices badge until the repository is actually enrolled and passing.
 
@@ -29,9 +29,9 @@ Do not add a passing OpenSSF Best Practices badge until the repository is actual
 ## Branch Protection And Release Integrity
 
 - `main` is the protected release branch.
-- `develop` is the integration branch for normal work, Renovate, and shared-assets PRs.
+- `develop` is the integration branch for normal work, Renovate, and shared-assets-lit PRs.
 - `develop` to `main` promotion PRs require manual review.
-- Renovate and shared-assets PRs may auto-merge only into `develop` after required checks pass.
+- Renovate and shared-assets-lit PRs may auto-merge only into `develop` after required checks pass.
 - Releases and publishing happen only from trusted `main` workflows after validation.
 - Release evidence is generated for repositories with release artifacts.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,43 @@
 # ee-wunder-ansible-ubi9
 
+<!-- BEGIN LIT_SHARED_RELEASE_MODEL -->
+
+## Release and Quality Model
+
+This repository follows the Lightning IT shared release and quality model.
+
+See [RELEASE.md](./RELEASE.md) for:
+
+- branch and release flow
+- required quality checks
+- test matrix
+- release evidence
+- artifact publishing
+- supported repository-specific release behavior
+
+Repository classification: **Container Image**.
+Required test profiles: `pre-commit, lint, container-build, container-smoke, trivy, release-validation`.
+Publishing targets: `github-release, quay.io`.
+
+## Supported and Tested Platforms
+
+| Platform / Product | Status | Validation |
+|---|---:|---|
+| ubuntu-latest | Supported | Container CI / Trivy |
+| ubi9 | Tested where applicable | Container CI / Trivy |
+| podman | Tested where applicable | Container CI / Trivy |
+| docker-buildx | Tested where applicable | Container CI / Trivy |
+
+<!-- END LIT_SHARED_RELEASE_MODEL -->
+
 <!-- BEGIN LIT_QUALITY_BADGES -->
 
 [![CI](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-ci.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-ci.yml)
 [![Latest Release](https://img.shields.io/github/v/release/lightning-it/container-ee-wunder-ansible-ubi9?sort=semver)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/releases/latest)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/lightning-it/container-ee-wunder-ansible-ubi9/badge)](https://scorecard.dev/viewer/?uri=github.com/lightning-it/container-ee-wunder-ansible-ubi9)
-[![Container Version](https://img.shields.io/github/v/release/lightning-it/container-ee-wunder-ansible-ubi9?sort=semver&label=Container%20Version)](https://quay.io/repository/l-it/ee-wunder-ansible-ubi9)
-[![Trivy](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-trivy.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-trivy.yml)
-[![Container Build](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build.yml)
+[![Quay.io](https://quay.io/repository/l-it/ee-wunder-ansible-ubi9/status)](https://quay.io/repository/l-it/ee-wunder-ansible-ubi9)
+[![Trivy](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build-publish.yml/badge.svg?branch=main)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build-publish.yml)
+[![Container Build](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build-publish.yml/badge.svg?branch=main)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build-publish.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
 <!-- END LIT_QUALITY_BADGES -->

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,7 @@ This repository follows the Lightning IT shared release and quality model.
 
 ## Branch Flow
 
-- `develop` is the integration branch for normal work, Renovate updates, and shared-assets synchronization.
+- `develop` is the integration branch for normal work, Renovate updates, and shared-assets-lit synchronization.
 - `main` is the protected release branch.
 - Releases happen only after `main` is updated.
 - A `develop` to `main` promotion PR is created automatically when releasable changes exist.

--- a/TESTING.md
+++ b/TESTING.md
@@ -26,7 +26,7 @@ Products and runtimes:
 ## When Tests Run
 
 - Normal pull requests run pre-commit, linting, syntax checks, and light tests relevant to changed files.
-- Renovate and shared-assets synchronization pull requests target `develop` and may auto-merge only after required checks pass.
+- Renovate and shared-assets-lit synchronization pull requests target `develop` and may auto-merge only after required checks pass.
 - `develop` to `main` promotion pull requests run the strongest validation profile for this repository.
 - Trusted `main` release workflows build and publish artifacts only after validation succeeds.
 


### PR DESCRIPTION
Consolidates repository governance on `lightning-it/shared-assets-lit`.

This PR updates:
- source-of-truth metadata from `shared-assets` to `shared-assets-lit`
- generated release/testing/OpenSSF docs
- license policy metadata and MIT license drift corrections where applicable
- repository-quality checks for license/source drift
