### PR TITLE
chore: promote container badge workflow fix

### DIFF
--- a/.lit/repository.yml
+++ b/.lit/repository.yml
@@ -27,6 +27,8 @@ galaxy_publish: false
 quay_publish: true
 release_evidence: true
 heavy_incus_required: false
+trivy_required: true
+trivy_release_gate: true
 readme_badges:
   - ci
   - container-build
@@ -36,6 +38,8 @@ readme_badges:
   - license
 workflows:
   ci: container-ci.yml
+  container_build: container-build.yml
   release: container-build-publish.yml
+  trivy: container-trivy.yml
   promote: promote-develop-to-main.yml
   backmerge: sync-main-to-develop.yml

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Publishing targets: `github-release, quay.io`.
 [![Latest Release](https://img.shields.io/github/v/release/lightning-it/container-ee-wunder-ansible-ubi9?sort=semver)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/releases/latest)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/lightning-it/container-ee-wunder-ansible-ubi9/badge)](https://scorecard.dev/viewer/?uri=github.com/lightning-it/container-ee-wunder-ansible-ubi9)
 [![Quay.io](https://quay.io/repository/l-it/ee-wunder-ansible-ubi9/status)](https://quay.io/repository/l-it/ee-wunder-ansible-ubi9)
-[![Trivy](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build-publish.yml/badge.svg?branch=main)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build-publish.yml)
-[![Container Build](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build-publish.yml/badge.svg?branch=main)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build-publish.yml)
+[![Trivy](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-trivy.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-trivy.yml)
+[![Container Build](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
 <!-- END LIT_QUALITY_BADGES -->


### PR DESCRIPTION
## Summary
- promote the container README badge workflow fix from develop to main
- keep Trivy and Container Build badges mapped to distinct workflows

## Tests
- PR checks