### PR TITLE
chore: fix quay container badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Publishing targets: `github-release, quay.io`.
 [![CI](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-ci.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-ci.yml)
 [![Latest Release](https://img.shields.io/github/v/release/lightning-it/container-ee-wunder-ansible-ubi9?sort=semver)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/releases/latest)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/lightning-it/container-ee-wunder-ansible-ubi9/badge)](https://scorecard.dev/viewer/?uri=github.com/lightning-it/container-ee-wunder-ansible-ubi9)
-[![Quay.io](https://quay.io/repository/l-it/ee-wunder-ansible-ubi9/status)](https://quay.io/repository/l-it/ee-wunder-ansible-ubi9)
+[![Quay.io](https://img.shields.io/badge/Quay.io-image-blue?logo=quay&logoColor=white)](https://quay.io/repository/l-it/ee-wunder-ansible-ubi9)
 [![Trivy](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-trivy.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-trivy.yml)
 [![Container Build](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build.yml/badge.svg?branch=develop)](https://github.com/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/container-build.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)


### PR DESCRIPTION
## Summary
- replace Quay /status README badge usage with a stable shields.io Quay image badge
- keep badge links pointed at the real Quay repository page
- add guardrails so generated badge blocks fail on Quay /status endpoints or placeholder states like container none

## Verification
- python3 scripts/audit-release-model.py
- python3 scripts/audit-container-trivy.py
- python3 scripts/lit-repository-quality.py
- python3 -m py_compile scripts/sync-release-model.py scripts/audit-release-model.py scripts/audit-container-trivy.py scripts/lit-repository-quality.py default/scripts/lit-repository-quality.py
- regenerated affected container READMEs