### PR TITLE
fix: allow review commit verification

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -13,6 +13,7 @@ on:
     types: [created, edited, deleted]
 
 permissions:
+  contents: read
   pull-requests: read
 
 env:


### PR DESCRIPTION
Grant the fail-closed Copilot review gate read-only contents access so it can verify the commit attached to each pull-request review. No write permission or bypass is added.