### PR TITLE
fix: migrate promotion workflow to release App

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,33 +1,718 @@
+# Managed by lightning-it/shared-assets-lit.
+# Do not edit downstream copies directly.
 # yamllint disable rule:truthy rule:line-length
 ---
-name: Request Copilot Review
+name: Copilot review gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 permissions:
   contents: read
+  pull-requests: read
+
+env:
+  COPILOT_REVIEWER_LOGIN: copilot-pull-request-reviewer
+  NO_FILES_REVIEW_MARKER: was not able to review any files
+  UNABLE_REVIEW_MARKER: unable to review this pull request
+  QUOTA_EXHAUSTED_MARKER: quota exhausted
+  QUOTA_EXCEEDED_MARKER: quota exceeded
+
+concurrency:
+  group: copilot-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
-  request-copilot-review:
-    name: Request Copilot advisory review
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+  request-current-revision-review:
+    name: Request Copilot review for current revision
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !(github.event.pull_request.user.login == 'renovate[bot]' &&
+        startsWith(github.event.pull_request.head.ref, 'renovate/') &&
+        github.event.pull_request.base.ref == 'develop') &&
+      !(github.event.pull_request.user.login == 'lightning-it-release-automation[bot]' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.head.ref == 'chore/sync-main-to-develop' &&
+        github.event.pull_request.base.ref == 'develop' &&
+        github.event.pull_request.title == 'chore: sync main back to develop') &&
+      !((github.event.pull_request.user.login == 'lightning-it-release-automation[bot]' ||
+          (github.event.pull_request.user.login == 'ghost' &&
+            github.event.pull_request.body == 'Promote the approved documentation production-acceptance and governance corrections from develop to main.')) &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.head.ref == 'develop' &&
+        github.event.pull_request.base.ref == 'main' &&
+        github.event.pull_request.title == 'chore(release): promote develop to main')
     permissions:
+      contents: read
       pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
-      - name: Request Copilot reviewer
+      - name: Request Copilot review for the current revision
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "${PR_AUTHOR}" = "lightning-it-shared-assets-sync[bot]" ] \
+            && [ "${PR_BASE}" = "develop" ] \
+            && { { [[ "${PR_HEAD}" == chore/sync-shared-assets-lit-* ]] \
+                && { [ "${PR_TITLE}" = "chore: sync shared-assets-lit" ] \
+                  || [ "${PR_TITLE}" = "chore: sync shared assets" ]; }; } \
+              || { [[ "${PR_HEAD}" == chore/sync-repository-quality-* ]] \
+                && [ "${PR_TITLE}" = "chore: sync repository quality assets" ]; }; }; then
+            for attempt in {1..6}; do
+              if ! live_pr="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}")"; then
+                echo "Live PR metadata unavailable; falling back to Copilot review."
+                break
+              fi
+              if jq -e --arg author "${PR_AUTHOR}" --arg base "${PR_BASE}" \
+                --arg head "${PR_HEAD}" --arg head_sha "${PR_HEAD_SHA}" \
+                --arg repo "${REPOSITORY}" --arg title "${PR_TITLE}" \
+                '(.state == "open") and (.draft == false) and (.user.login == $author)
+                 and (.base.ref == $base) and (.head.ref == $head)
+                 and (.head.sha == $head_sha) and (.head.repo.full_name == $repo)
+                 and (.title == $title)
+                 and ([.labels[].name] | index("chore") != null)
+                 and ([.labels[].name] | index("shared-assets-lit") != null)' \
+                <<<"${live_pr}" >/dev/null; then
+                echo "Trusted sync PR verified from live metadata; Copilot request skipped."
+                exit 0
+              fi
+              [ "${attempt}" -eq 6 ] || sleep 5
+            done
+          fi
+          reviewer_login="${COPILOT_REVIEWER_LOGIN%\[bot\]}"
+          reviewer="${reviewer_login}[bot]"
+          requested_reviewers_url="repos/${REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers"
+          reviewer_is_requested() {
+            local response
+            if ! response="$(gh api "${requested_reviewers_url}")"; then
+              return 2
+            fi
+            jq -e --arg reviewer "${reviewer}" \
+              'any(.users[]?; .login == $reviewer)' <<<"${response}" >/dev/null
+          }
+          if reviewer_is_requested; then
+            echo "Copilot review is already requested for the current PR."
+          else
+            request_status=$?
+            if [ "${request_status}" -ne 1 ]; then
+              exit "${request_status}"
+            fi
+            if ! gh api --method POST "${requested_reviewers_url}" \
+                -f "reviewers[]=${reviewer}"
+            then
+              # A concurrent workflow can win the request race. Accept only
+              # that verified idempotent outcome; fail on absence/API errors.
+              if reviewer_is_requested; then
+                echo "A concurrent workflow already requested Copilot review."
+              else
+                verification_status=$?
+                exit "${verification_status}"
+              fi
+            fi
+          fi
+
+  current-revision-reviewed:
+    name: Successful Copilot review
+    if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Classify trusted automation pull request
+        id: trusted-automation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          trusted=false
+          trusted_kind=none
+          release_tag=""
+          live_pr="{}"
+          if [ "${PR_AUTHOR}" = "renovate[bot]" ] \
+            && [ "${PR_HEAD_REPO}" = "${REPOSITORY}" ] \
+            && [[ "${PR_HEAD}" == renovate/* ]] \
+            && [ "${PR_BASE}" = "develop" ]; then
+            if live_pr="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}")" \
+              && jq -e \
+              --arg author "${PR_AUTHOR}" \
+              --arg base "${PR_BASE}" \
+              --arg head "${PR_HEAD}" \
+              --arg head_sha "${PR_HEAD_SHA}" \
+              --arg repo "${REPOSITORY}" \
+              '(.state == "open") and (.draft == false)
+               and (.user.login == $author) and (.base.ref == $base)
+               and (.head.ref == $head) and (.head.sha == $head_sha)
+               and (.head.repo.full_name == $repo)
+               and ([.labels[].name] | index("renovate") != null)
+               and ([.labels[].name] | index("dependencies") != null)
+               and ([.labels[].name] | index("safe-automerge") != null)
+               and ([.labels[].name] | index("breaking-update") == null)' \
+                <<<"${live_pr}" >/dev/null; then
+              trusted=true
+              trusted_kind=renovate
+            fi
+          elif [ "${PR_AUTHOR}" = "lightning-it-shared-assets-sync[bot]" ] \
+            && [ "${PR_HEAD_REPO}" = "${REPOSITORY}" ] \
+            && [[ "${PR_HEAD}" == chore/sync-shared-assets-lit-* ]] \
+            && [ "${PR_BASE}" = "develop" ] \
+            && { [ "${PR_TITLE}" = "chore: sync shared-assets-lit" ] \
+              || [ "${PR_TITLE}" = "chore: sync shared assets" ]; } \
+            && live_pr="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}")" \
+            && jq -e \
+              --arg author "${PR_AUTHOR}" --arg base "${PR_BASE}" \
+              --arg head "${PR_HEAD}" --arg head_sha "${PR_HEAD_SHA}" --arg title "${PR_TITLE}" \
+              --arg repo "${REPOSITORY}" \
+              '(.state == "open") and (.draft == false)
+               and (.user.login == $author) and (.base.ref == $base)
+               and (.head.ref == $head) and (.head.sha == $head_sha) and (.title == $title)
+               and (.head.repo.full_name == $repo)
+               and ([.labels[].name] | index("chore") != null)
+               and ([.labels[].name] | index("shared-assets-lit") != null)' \
+              <<<"${live_pr}" >/dev/null; then
+            trusted=true
+            trusted_kind=shared-assets
+          elif [ "${PR_AUTHOR}" = "lightning-it-shared-assets-sync[bot]" ] \
+            && [ "${PR_HEAD_REPO}" = "${REPOSITORY}" ] \
+            && [[ "${PR_HEAD}" == chore/sync-repository-quality-* ]] \
+            && [ "${PR_BASE}" = "develop" ] \
+            && [ "${PR_TITLE}" = "chore: sync repository quality assets" ] \
+            && live_pr="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}")" \
+            && jq -e \
+              --arg author "${PR_AUTHOR}" --arg base "${PR_BASE}" \
+              --arg head "${PR_HEAD}" --arg head_sha "${PR_HEAD_SHA}" --arg title "${PR_TITLE}" \
+              --arg repo "${REPOSITORY}" \
+              '(.state == "open") and (.draft == false)
+               and (.user.login == $author) and (.base.ref == $base)
+               and (.head.ref == $head) and (.head.sha == $head_sha) and (.title == $title)
+               and (.head.repo.full_name == $repo)
+               and ([.labels[].name] | index("chore") != null)
+               and ([.labels[].name] | index("shared-assets-lit") != null)' \
+              <<<"${live_pr}" >/dev/null; then
+            trusted=true
+            trusted_kind=repository-quality
+          elif [ "${PR_AUTHOR}" = "lightning-it-release-automation[bot]" ] \
+            && [ "${PR_HEAD_REPO}" = "${REPOSITORY}" ] \
+            && [ "${PR_HEAD}" = "chore/sync-main-to-develop" ] \
+            && [ "${PR_BASE}" = "develop" ] \
+            && [ "${PR_TITLE}" = "chore: sync main back to develop" ]; then
+            trusted=true
+            trusted_kind=ancestry-backmerge
+          elif [ "${PR_AUTHOR}" = "lightning-it-release-automation[bot]" ] \
+            && [ "${PR_HEAD_REPO}" = "${REPOSITORY}" ] \
+            && [[ "${PR_HEAD}" == backsync/release-v*-to-develop ]] \
+            && [ "${PR_BASE}" = "develop" ] \
+            && jq -e 'index("skip-changelog") != null' \
+              <<<"${PR_LABELS}" >/dev/null; then
+            release_tag="${PR_HEAD#backsync/release-}"
+            release_tag="${release_tag%-to-develop}"
+            if [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+              && [ "${PR_TITLE}" = "chore: sync ${release_tag} release back to develop" ]; then
+              trusted=true
+              trusted_kind=release-backsync
+            fi
+          elif { [ "${PR_AUTHOR}" = "lightning-it-release-automation[bot]" ] \
+              || { [ "${PR_AUTHOR}" = "ghost" ] \
+                && [ "${PR_BODY}" = "Promote the approved documentation production-acceptance and governance corrections from develop to main." ]; }; } \
+            && [ "${PR_HEAD_REPO}" = "${REPOSITORY}" ] \
+            && [ "${PR_HEAD}" = "develop" ] \
+            && [ "${PR_BASE}" = "main" ] \
+            && [ "${PR_TITLE}" = "chore(release): promote develop to main" ]; then
+            trusted=true
+            trusted_kind=release-promotion
+          fi
+          {
+            echo "trusted=${trusted}"
+            echo "kind=${trusted_kind}"
+            echo "release_tag=${release_tag}"
+          } >>"${GITHUB_OUTPUT}"
+
+      - name: Verify file-identical ancestry backmerge
+        if: steps.trusted-automation.outputs.kind == 'ancestry-backmerge'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          gh auth setup-git
+          git init --quiet .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --quiet --no-tags origin \
+            "${HEAD_SHA}" "refs/heads/main" "refs/heads/develop"
+          git merge-base --is-ancestor "origin/main" "${HEAD_SHA}"
+          git merge-base --is-ancestor "origin/develop" "${HEAD_SHA}"
+          [ "$(git rev-list --parents -n 1 "${HEAD_SHA}" | wc -w)" -eq 3 ]
+          git diff --quiet "origin/develop" "${HEAD_SHA}"
+          echo "Verified a develop-tree-preserving two-parent merge of current main and develop."
+
+      - name: Verify protected release promotion
+        if: steps.trusted-automation.outputs.kind == 'release-promotion'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          gh auth setup-git
+          git init --quiet .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --quiet --no-tags origin \
+            "${HEAD_SHA}" "refs/heads/main" "refs/heads/develop"
+          [ "$(git rev-parse origin/develop)" = "${HEAD_SHA}" ]
+          git merge-base --is-ancestor "origin/main" "${HEAD_SHA}"
+          echo "Verified current protected develop head and main ancestry."
+
+      - name: Verify release back-sync merge and bounded files
+        if: steps.trusted-automation.outputs.kind == 'release-backsync'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RELEASE_TAG: ${{ steps.trusted-automation.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          gh auth setup-git
+          git init --quiet .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --quiet --no-tags origin \
+            "${HEAD_SHA}" "${BASE_SHA}" "refs/heads/main" "refs/heads/develop" \
+            "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          [ "$(git rev-parse origin/develop)" = "${BASE_SHA}" ]
+          [ "$(git rev-list --parents -n 1 "${HEAD_SHA}" | wc -w)" -eq 3 ]
+          [ "$(git rev-parse "${HEAD_SHA}^1")" = "${BASE_SHA}" ]
+          release_sha="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+          [ "$(git rev-parse "${HEAD_SHA}^2")" = "${release_sha}" ]
+          git merge-base --is-ancestor "${release_sha}" origin/main
+          if git diff --quiet "${BASE_SHA}" "${HEAD_SHA}"; then
+            echo "Release back-sync does not contain release-generated changes." >&2
+            exit 1
+          fi
+          unexpected="$(
+            git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" |
+              awk '$0 != "CHANGELOG.rst" && $0 != "galaxy.yml" && $0 !~ /^changelogs\//'
+          )"
+          [ -z "${unexpected}" ] || {
+            echo "Release back-sync contains files outside the allowed release paths:" >&2
+            printf '%s\n' "${unexpected}" >&2
+            exit 1
+          }
+          echo "Verified release-tag merge and bounded release-generated files."
+
+      - name: Accept trusted automation exemption
+        if: >-
+          steps.trusted-automation.outputs.trusted == 'true' &&
+          steps.trusted-automation.outputs.kind != 'ancestry-backmerge' &&
+          steps.trusted-automation.outputs.kind != 'release-promotion' &&
+          steps.trusted-automation.outputs.kind != 'release-backsync'
+        run: |
+          if [ "${{ steps.trusted-automation.outputs.kind }}" = renovate ]; then
+            {
+              echo "### Trusted Renovate exemption"
+              echo
+              echo "Copilot review is not required for this exact-head trusted Renovate PR."
+              echo "Trusted identity and policy verification succeeded."
+            } >>"${GITHUB_STEP_SUMMARY}"
+          else
+            echo "Trusted automation PR; Copilot review is delegated to its required guarded-automerge policy."
+          fi
+
+      - name: Verify current Copilot review and resolved findings
+        if: steps.trusted-automation.outputs.trusted != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          gh api \
-            --method POST \
-            "repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
-            -f reviewers[]=copilot-pull-request-reviewer \
-            || echo "Copilot reviewer is unavailable for this repository; continuing."
+          owner="${REPOSITORY%%/*}"
+          repository="${REPOSITORY#*/}"
+
+          graphql() {
+            local api_attempt output
+            for api_attempt in $(seq 1 5); do
+              if output="$(gh api graphql "$@")"; then
+                if jq -e '((.errors // []) | length) == 0' <<<"${output}" >/dev/null; then
+                  printf '%s' "${output}"
+                  return 0
+                fi
+                jq -r '.errors[]?.message' <<<"${output}" >&2
+              fi
+              echo "GitHub GraphQL request failed (attempt ${api_attempt}/5)." >&2
+              sleep 5
+            done
+            return 1
+          }
+
+          read -r -d '' review_query <<'GRAPHQL' || true
+          query(
+            $owner: String!
+            $repository: String!
+            $number: Int!
+            $before: String
+          ) {
+            repository(owner: $owner, name: $repository) {
+              pullRequest(number: $number) {
+                headRefOid
+                reviews(last: 100, before: $before) {
+                  pageInfo { hasPreviousPage startCursor }
+                  nodes {
+                    id
+                    author { login }
+                    commit { oid }
+                    state
+                  }
+                }
+              }
+            }
+          }
+          GRAPHQL
+
+          read -r -d '' review_comments_query <<'GRAPHQL' || true
+          query(
+            $review: ID!
+            $after: String
+          ) {
+            node(id: $review) {
+              ... on PullRequestReview {
+                body
+                commit { oid }
+                pullRequest { headRefOid }
+                comments(first: 100, after: $after) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes { body }
+                }
+              }
+            }
+          }
+          GRAPHQL
+
+          review_comments_clean() {
+            local review_id="$1" expected_head="$2" after="" response has_next
+            local content_counts marker_count content_count meaningful_content=false
+            local count_pattern=$'^[0-9]+\t[0-9]+$'
+            local -a arguments
+            while true; do
+              arguments=(
+                -f query="${review_comments_query}"
+                -f review="${review_id}"
+              )
+              if [ -n "${after}" ]; then
+                arguments+=(-f after="${after}")
+              fi
+
+              if ! response="$(graphql "${arguments[@]}")"; then
+                return 2
+              fi
+              if ! jq -e \
+                --arg head "${expected_head}" \
+                '(.data.node.comments != null)
+                  and (.data.node.commit.oid == $head)
+                  and (.data.node.pullRequest.headRefOid == $head)' \
+                <<<"${response}" >/dev/null; then
+                echo "Review ${review_id} no longer matches current head ${expected_head}." >&2
+                return 2
+              fi
+
+              if ! content_counts="$(
+                jq -er \
+                  --arg unable_marker "${UNABLE_REVIEW_MARKER}" \
+                  --arg no_files_marker "${NO_FILES_REVIEW_MARKER}" \
+                  --arg quota_exhausted_marker "${QUOTA_EXHAUSTED_MARKER}" \
+                  --arg quota_exceeded_marker "${QUOTA_EXCEEDED_MARKER}" \
+                  'def normalize_review_text:
+                      ascii_downcase
+                      | gsub("wasn[\u0027\u2019]t"; "was not")
+                      | gsub("\\s"; "");
+                  def review_content:
+                      (.data.node.body // ""),
+                      (.data.node.comments.nodes[]?.body // "");
+                  ($unable_marker | normalize_review_text) as $unable
+                  | ($no_files_marker | normalize_review_text) as $no_files
+                  | ($quota_exhausted_marker | normalize_review_text) as $quota_exhausted
+                  | ($quota_exceeded_marker | normalize_review_text) as $quota_exceeded
+                  | [
+                    ([
+                      review_content
+                      | select(
+                          normalize_review_text
+                          | (
+                              contains($unable)
+                              or contains($no_files)
+                              or contains($quota_exhausted)
+                              or contains($quota_exceeded)
+                            )
+                        )
+                    ] | length),
+                    ([
+                      review_content
+                      | select((gsub("\\s"; "")) != "")
+                    ] | length)
+                  ]
+                  | @tsv' <<<"${response}"
+              )"; then
+                echo "Unable to parse review content counts for review ${review_id}; refusing to accept the review." >&2
+                return 2
+              fi
+              if [[ ! "${content_counts}" =~ ${count_pattern} ]]; then
+                echo "Review ${review_id} returned invalid review content counts; refusing to accept the review." >&2
+                return 2
+              fi
+              IFS=$'\t' read -r marker_count content_count <<<"${content_counts}"
+              if [ "${marker_count}" -gt 0 ]; then
+                return 1
+              fi
+              if [ "${content_count}" -gt 0 ]; then
+                meaningful_content=true
+              fi
+
+              has_next="$(jq -r '.data.node.comments.pageInfo.hasNextPage' <<<"${response}")"
+              if [ "${has_next}" != "true" ]; then
+                if [ "${meaningful_content}" = true ]; then
+                  return 0
+                fi
+                return 1
+              fi
+              after="$(jq -r '.data.node.comments.pageInfo.endCursor // empty' <<<"${response}")"
+              if [ -z "${after}" ]; then
+                echo "Review-comment pagination cursor is missing." >&2
+                return 2
+              fi
+            done
+          }
+
+          # A rejected review cannot become acceptable during this run without
+          # an edit event, which starts a fresh run through the concurrency
+          # group. Cache rejected IDs so marker-only, empty, or whitespace-only
+          # reviews cost one detail query per run instead of one query on every
+          # polling attempt.
+          declare -A rejected_review_ids=()
+          review_complete=false
+          head_sha=""
+          for attempt in $(seq 1 40); do
+            head_sha=""
+            before=""
+            request_failed=false
+            while true; do
+              arguments=(
+                -f query="${review_query}"
+                -F owner="${owner}"
+                -F repository="${repository}"
+                -F number="${PR_NUMBER}"
+              )
+              if [ -n "${before}" ]; then
+                arguments+=(-f before="${before}")
+              fi
+
+              if ! response="$(graphql "${arguments[@]}")"; then
+                request_failed=true
+                break
+              fi
+
+              page_head_sha="$(jq -r '.data.repository.pullRequest.headRefOid // empty' <<<"${response}")"
+              if [ -z "${page_head_sha}" ]; then
+                echo "Unable to determine the pull request head SHA." >&2
+                exit 1
+              fi
+              if [ -n "${head_sha}" ] && [ "${head_sha}" != "${page_head_sha}" ]; then
+                echo "Pull request head changed during review verification; retrying." >&2
+                request_failed=true
+                break
+              fi
+              head_sha="${page_head_sha}"
+
+              candidate_review_ids="$(
+                jq -r \
+                  --arg head "${head_sha}" \
+                  --arg reviewer "${COPILOT_REVIEWER_LOGIN}" \
+                  '(.data.repository.pullRequest.reviews.nodes // [])[]
+                    | select(
+                        (.author.login // "") as $login
+                        | ($login == $reviewer or $login == ($reviewer + "[bot]"))
+                      )
+                    | select(.state == "COMMENTED")
+                    | select(.commit.oid == $head)
+                    | (.id // empty)' <<<"${response}"
+              )"
+              while IFS= read -r review_id; do
+                if [ -z "${review_id}" ]; then
+                  continue
+                fi
+                if [ -n "${rejected_review_ids["${review_id}"]:-}" ]; then
+                  continue
+                fi
+                if review_comments_clean "${review_id}" "${head_sha}"; then
+                  review_complete=true
+                  break
+                else
+                  comments_status=$?
+                  if [ "${comments_status}" -eq 2 ]; then
+                    request_failed=true
+                    break
+                  fi
+                  rejected_review_ids["${review_id}"]=1
+                fi
+              done <<<"${candidate_review_ids}"
+              if [ "${review_complete}" = true ]; then
+                break 2
+              fi
+              if [ "${request_failed}" = true ]; then
+                break
+              fi
+
+              has_previous="$(jq -r '.data.repository.pullRequest.reviews.pageInfo.hasPreviousPage' <<<"${response}")"
+              if [ "${has_previous}" != "true" ]; then
+                break
+              fi
+              before="$(jq -r '.data.repository.pullRequest.reviews.pageInfo.startCursor // empty' <<<"${response}")"
+              if [ -z "${before}" ]; then
+                echo "Review pagination cursor is missing." >&2
+                exit 1
+              fi
+            done
+
+            if [ "${attempt}" -eq 40 ]; then
+              if [ "${request_failed}" = true ]; then
+                echo "Unable to verify the Copilot review after repeated API or head-change failures." >&2
+              else
+                echo "GitHub Copilot has not completed a review of current head ${head_sha:-unknown}." >&2
+              fi
+              exit 1
+            fi
+            if [ "${request_failed}" = true ]; then
+              echo "Retrying review verification after a transient API or head-change failure."
+            else
+              echo "Waiting for GitHub Copilot to review current head ${head_sha} (attempt ${attempt}/40)."
+            fi
+            sleep 15
+          done
+
+          if [ "${review_complete}" != true ]; then
+            echo "GitHub Copilot review verification ended unexpectedly." >&2
+            exit 1
+          fi
+
+          read -r -d '' thread_query <<'GRAPHQL' || true
+          query(
+            $owner: String!
+            $repository: String!
+            $number: Int!
+            $after: String
+          ) {
+            repository(owner: $owner, name: $repository) {
+              pullRequest(number: $number) {
+                headRefOid
+                reviewThreads(first: 100, after: $after) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes {
+                    isResolved
+                    comments(first: 1) {
+                      nodes { author { login } }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          GRAPHQL
+
+          findings_resolved=false
+          for resolution_attempt in $(seq 1 20); do
+            after=""
+            unresolved_copilot_threads=0
+            request_failed=false
+            while true; do
+              arguments=(
+                -f query="${thread_query}"
+                -F owner="${owner}"
+                -F repository="${repository}"
+                -F number="${PR_NUMBER}"
+              )
+              if [ -n "${after}" ]; then
+                arguments+=(-f after="${after}")
+              fi
+
+              if ! response="$(graphql "${arguments[@]}")"; then
+                request_failed=true
+                break
+              fi
+
+              page_head_sha="$(jq -r '.data.repository.pullRequest.headRefOid // empty' <<<"${response}")"
+              if [ "${page_head_sha}" != "${head_sha}" ]; then
+                echo "Pull request head changed during thread verification; retrying." >&2
+                request_failed=true
+                break
+              fi
+
+              page_unresolved="$(
+                jq \
+                  --arg reviewer "${COPILOT_REVIEWER_LOGIN}" \
+                  '[
+                    (.data.repository.pullRequest.reviewThreads.nodes // [])[]
+                    | select(.isResolved == false)
+                    | select(
+                        (.comments.nodes[0].author.login // "") as $login
+                        | ($login == $reviewer or $login == ($reviewer + "[bot]"))
+                      )
+                  ]
+                  | length' <<<"${response}"
+              )"
+              unresolved_copilot_threads=$((unresolved_copilot_threads + page_unresolved))
+
+              has_next="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<<"${response}")"
+              if [ "${has_next}" != "true" ]; then
+                break
+              fi
+              after="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty' <<<"${response}")"
+              if [ -z "${after}" ]; then
+                echo "Review-thread pagination cursor is missing." >&2
+                exit 1
+              fi
+            done
+
+            if [ "${request_failed}" = false ] && [ "${unresolved_copilot_threads}" -eq 0 ]; then
+              findings_resolved=true
+              break
+            fi
+            if [ "${resolution_attempt}" -eq 20 ]; then
+              if [ "${request_failed}" = true ]; then
+                echo "Unable to verify Copilot review threads after repeated API or head-change failures." >&2
+              else
+                echo "${unresolved_copilot_threads} unresolved GitHub Copilot review thread(s) remain." >&2
+              fi
+              exit 1
+            fi
+            echo "Waiting for GitHub Copilot findings to be resolved (attempt ${resolution_attempt}/20)."
+            sleep 15
+          done
+
+          if [ "${findings_resolved}" != true ]; then
+            echo "GitHub Copilot thread verification ended unexpectedly." >&2
+            exit 1
+          fi
+
+          echo "GitHub Copilot reviewed current head ${head_sha}; no unresolved Copilot findings remain."

--- a/.github/workflows/promote-develop-to-main.yml
+++ b/.github/workflows/promote-develop-to-main.yml
@@ -11,50 +11,66 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   promote:
     name: Open develop-to-main promotion PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
-      - name: Validate bot token
-        env:
-          GH_TOKEN: ${{ secrets.LITRELEASEBOT_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::Missing required secret: secrets.LITRELEASEBOT_TOKEN"
-            exit 1
-          fi
-
-          if ! gh auth status --hostname github.com >/dev/null 2>&1; then
-            echo "::error::secrets.LITRELEASEBOT_TOKEN is not a valid GitHub token"
-            exit 1
-          fi
-
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Mint release automation App token
+        id: release-app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Resolve release automation App bot identity
+        id: release-bot
+        env:
+          APP_SLUG: ${{ steps.release-app.outputs.app-slug }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          bot_json="$(gh api "users/${APP_SLUG}%5Bbot%5D" 2>/dev/null || printf '{}')"
+          login="$(jq -r '.login // ""' <<<"$bot_json")"
+          bot_id="$(jq -r '.id // ""' <<<"$bot_json")"
+          if [ "$login" != "${APP_SLUG}[bot]" ] || ! [[ "$bot_id" =~ ^[0-9]+$ ]]; then
+            echo "::error::Unable to resolve the release automation App bot identity."
+            exit 1
+          fi
+          echo "login=$login" >>"$GITHUB_OUTPUT"
+          echo "email=${bot_id}+${login}@users.noreply.github.com" >>"$GITHUB_OUTPUT"
+
       - name: Create or update promotion PR
         env:
-          BOT_TOKEN: ${{ secrets.LITRELEASEBOT_TOKEN }}
+          BOT_TOKEN: ${{ steps.release-app.outputs.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          if [ -z "${BOT_TOKEN:-}" ]; then
-            echo "::error::Missing required secret: secrets.LITRELEASEBOT_TOKEN"
-            exit 1
+          pr_token="${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+          if [ -n "${BOT_TOKEN:-}" ]; then
+            if GH_TOKEN="$BOT_TOKEN" gh api 'users/lightning-it-release-automation%5Bbot%5D' --jq '.login' >/dev/null 2>&1; then
+              pr_token="$BOT_TOKEN"
+            else
+              echo "release automation App token is not valid; falling back to GITHUB_TOKEN."
+            fi
           fi
 
-          if ! GH_TOKEN="$BOT_TOKEN" gh auth status --hostname github.com >/dev/null 2>&1; then
-            echo "::error::secrets.LITRELEASEBOT_TOKEN is not a valid GitHub token"
+          if ! GH_TOKEN="$pr_token" gh auth status --hostname github.com >/dev/null 2>&1; then
+            echo "No valid GitHub token is available for promotion PRs."
             exit 1
           fi
 
@@ -71,7 +87,7 @@ jobs:
           fi
 
           title="chore(release): promote develop to main"
-          pr_url="$(GH_TOKEN="$BOT_TOKEN" gh pr list \
+          pr_url="$(GH_TOKEN="$pr_token" gh pr list \
             --repo "$REPO" \
             --base main \
             --head develop \
@@ -85,7 +101,7 @@ jobs:
               echo "Sync main back to develop before opening a promotion PR."
             }
             if [ -n "$pr_url" ]; then
-              GH_TOKEN="$BOT_TOKEN" gh pr close "$pr_url" \
+              GH_TOKEN="$pr_token" gh pr close "$pr_url" \
                 --repo "$REPO" \
                 --comment "Closing stale promotion PR: main is not an ancestor of develop."
             fi
@@ -95,7 +111,7 @@ jobs:
           if git diff --quiet origin/main origin/develop -- .; then
             echo "develop and main have no file differences; promotion not needed."
             if [ -n "$pr_url" ]; then
-              GH_TOKEN="$BOT_TOKEN" gh pr close "$pr_url" \
+              GH_TOKEN="$pr_token" gh pr close "$pr_url" \
                 --repo "$REPO" \
                 --comment "Closing empty promotion PR: develop and main have no file differences."
             fi
@@ -111,14 +127,14 @@ jobs:
           body+=$'ancestor of `main`.'
 
           if [ -z "$pr_url" ]; then
-            GH_TOKEN="$BOT_TOKEN" gh pr create \
+            GH_TOKEN="$pr_token" gh pr create \
               --repo "$REPO" \
               --base main \
               --head develop \
               --title "$title" \
               --body "$body"
           else
-            GH_TOKEN="$BOT_TOKEN" gh pr edit "$pr_url" \
+            GH_TOKEN="$pr_token" gh pr edit "$pr_url" \
               --repo "$REPO" \
               --title "$title" \
               --body "$body"


### PR DESCRIPTION
## Summary

Copies the already-reviewed GitHub App promotion workflow and the matching required Copilot review gate from `develop` to `main` to resolve #412.

## Root cause

The organization client-ID variable was restricted to private repositories. In addition, `main` still referenced the removed legacy release token and required a `Successful Copilot review` check while containing only the obsolete advisory workflow that could not produce that check.

## Scope

- Align the promotion workflow with the centrally managed App-authentication version already on `develop`.
- Align the Copilot gate with the version already on `develop`, restoring the check required by the `main` branch rules.

## Validation

- The promotion workflow succeeds on `develop` after the organization variable fix.
- After merge, the promotion workflow will be dispatched on `main` and linked in #412.

Closes #412