### PR TITLE
fix(release): reclaim disk before release verification

### DIFF
--- a/.github/workflows/container-build-publish.yml
+++ b/.github/workflows/container-build-publish.yml
@@ -325,6 +325,14 @@ jobs:
             org.opencontainers.image.title=${{ github.event.repository.name }}-bootstrap
             org.opencontainers.image.description=${{ github.event.repository.description }}
 
+      - name: Reclaim build cache before release verification
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker buildx prune --all --force
+          docker image prune --all --force
+          df -h /
+
       - name: Verify, scan, sign, and summarize public image
         shell: bash
         env:


### PR DESCRIPTION
Apply the exact centrally managed shared-assets-lit workflow fix from PR #578. After all three multi-arch images are pushed, prune Buildx and unused Docker image data so Trivy has enough runner disk for database extraction, verification, signing, and release evidence.

Validation:
- central shared-assets repository quality passed
- central 207-unit-test suite passed
- downstream YAML and basic pre-commit hooks passed
- the full downstream parity hook reached only unrelated pre-existing node_modules YAML files in the local worktree; PR CI runs from a clean checkout