### PR TITLE
fix(container): document Trivy release workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Required repository configuration:
 - Secrets: `QUAY_USERNAME`, `QUAY_PASSWORD`
 - Secret for certified profile build: `RH_AUTOMATION_HUB_TOKEN`
 
+Release verification uses an isolated 4 GiB temporary workspace for the Trivy database and image scan.
+
 ## Local builds
 
 Public image:


### PR DESCRIPTION
## Summary
- document why release verification reserves a 4 GiB isolated Trivy tmpfs
- create a release-significant fix commit for the centrally synchronized runtime correction

## Validation
- bash -n scripts/devtools-container-release-verify.sh
- git diff --check
- targeted pre-commit formatting hooks passed

Full local container parity reached existing unrelated node_modules YAML files; the clean GitHub CI checkout is authoritative for the full parity run.