### PR TITLE
fix(deps): update lit.supplementary to 2.0.3

### DIFF
--- a/collections/requirements-base.yml
+++ b/collections/requirements-base.yml
@@ -5,7 +5,7 @@ collections:
   - name: lit.rhel
     version: "1.17.1"
   - name: lit.supplementary
-    version: "1.40.0"
+    version: "2.0.3"
   - name: lit.ocp
     version: "1.3.15"
   - name: ansible.posix


### PR DESCRIPTION
Emergency customer unblock: update the execution environment from lit.supplementary 1.40.0 to the published and verified 2.0.3 release containing the AAP preflight expected-FQDN DNS fix. YAML and diff checks pass.