### PR TITLE
fix(collections): update supplementary to 2.1.0

### DIFF
--- a/collections/requirements-base.yml
+++ b/collections/requirements-base.yml
@@ -5,7 +5,7 @@ collections:
   - name: lit.rhel
     version: "1.17.1"
   - name: lit.supplementary
-    version: "2.0.3"
+    version: "2.1.0"
   - name: lit.ocp
     version: "1.3.15"
   - name: ansible.posix


### PR DESCRIPTION
Emergency AAP customer rollout update. Pins the newly published lit.supplementary 2.1.0 containing the AAP substrate, SELinux, TLS-source, FQDN, artifact, and Hub registry fixes.