### PR TITLE
fix(collections): update lit.supplementary to 3.0.1

### DIFF
--- a/collections/requirements-base.yml
+++ b/collections/requirements-base.yml
@@ -5,7 +5,7 @@ collections:
   - name: lit.rhel
     version: "1.17.1"
   - name: lit.supplementary
-    version: "2.1.0"
+    version: "3.0.1"
   - name: lit.ocp
     version: "1.3.15"
   - name: ansible.posix


### PR DESCRIPTION
## Summary

- pin the public and certified EE builds to lit.supplementary 3.0.1
- include the AAP public-gateway fix for Hub readiness and image seeding

## Validation

- full devtools container CI parity passed locally
- Galaxy installed lit.supplementary 3.0.1 during the image build
- complete image build passed
- Trivy CRITICAL release gate passed
- Renovate config validation passed
- semantic-release dry-run passed