### PR TITLE
fix(deps): update lit.supplementary to 3.1.0

### DIFF
--- a/collections/requirements-base.yml
+++ b/collections/requirements-base.yml
@@ -5,7 +5,7 @@ collections:
   - name: lit.rhel
     version: "1.17.1"
   - name: lit.supplementary
-    version: "3.0.1"
+    version: "3.1.0"
   - name: lit.ocp
     version: "1.3.15"
   - name: ansible.posix


### PR DESCRIPTION
Updates the customer execution environment to the verified lit.supplementary v3.1.0 release.\n\nRelease: https://github.com/lightning-it/ansible-collection-supplementary/releases/tag/v3.1.0\n\nLocal YAML and whitespace checks passed. Full container parity is delegated to clean GitHub CI because the local container engine is unavailable and the local node_modules tree causes unrelated lint noise.