### PR TITLE
feat: verify MLX-90 container releases

### DIFF
--- a/.github/workflows/security-release-finalize.yml
+++ b/.github/workflows/security-release-finalize.yml
@@ -1,0 +1,37 @@
+# MLX-90 finalizer. Dispatch is restricted to the trusted release App by repository policy.
+# yamllint disable rule:truthy rule:line-length
+---
+name: Security release final acceptance
+on:
+  repository_dispatch:
+    types: [security-release-finalize]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  verify-published-digest:
+    name: Pull and verify published container digest
+    runs-on: ubuntu-latest
+    environment: security-release-acceptance
+    steps:
+      - name: Checkout accepted main revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ github.event.client_payload.consumer_merge_sha }}
+          persist-credentials: false
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Verify immutable release and fix acceptance
+        shell: bash
+        env:
+          IMAGE_REF: ${{ github.event.client_payload.image_ref }}
+          EXPECTED_COLLECTION: ${{ github.event.client_payload.collection }}
+          EXPECTED_VERSION: ${{ github.event.client_payload.collection_version }}
+          ACCEPTANCE_COMMAND: ${{ vars.MLX90_ACCEPTANCE_COMMAND }}
+          COSIGN_IDENTITY_REGEXP: ${{ vars.MLX90_COSIGN_IDENTITY_REGEXP }}
+          COSIGN_ISSUER: ${{ vars.MLX90_COSIGN_ISSUER }}
+        run: scripts/security-release-container-acceptance.sh

--- a/.releaserc
+++ b/.releaserc
@@ -2,7 +2,7 @@
   "branches": ["main"],
   "preset": "conventionalcommits",
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    ["@semantic-release/commit-analyzer", {"releaseRules": [{"type": "chore", "scope": "deps", "release": "patch"}, {"type": "fix", "scope": "security", "release": "patch"}]}],
     "@semantic-release/release-notes-generator",
     ["@semantic-release/github", { "assets": [] }]
   ]

--- a/.releaserc
+++ b/.releaserc
@@ -2,7 +2,7 @@
   "branches": ["main"],
   "preset": "conventionalcommits",
   "plugins": [
-    ["@semantic-release/commit-analyzer", {"releaseRules": [{"type": "chore", "scope": "deps", "release": "patch"}, {"type": "fix", "scope": "security", "release": "patch"}]}],
+    "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/github", { "assets": [] }]
   ]

--- a/scripts/security-release-container-acceptance.sh
+++ b/scripts/security-release-container-acceptance.sh
@@ -9,14 +9,12 @@ set -euo pipefail
 : "${COSIGN_IDENTITY_REGEXP:?COSIGN_IDENTITY_REGEXP is required}"
 : "${COSIGN_ISSUER:?COSIGN_ISSUER is required}"
 
-case "$IMAGE_REF" in
-  *@sha256:[0-9a-f][0-9a-f]*) ;;
-  *) echo "ERROR: IMAGE_REF must be immutable" >&2; exit 1 ;;
-esac
+[[ "$IMAGE_REF" =~ @sha256:([0-9a-f]{64})$ ]] || { echo "ERROR: IMAGE_REF must end in a full immutable SHA-256 digest" >&2; exit 1; }
+expected_digest="${BASH_REMATCH[1]}"
 
 docker pull "$IMAGE_REF"
-resolved="$(docker image inspect "$IMAGE_REF" --format '{{index .RepoDigests 0}}')"
-[ "$resolved" = "$IMAGE_REF" ] || { echo "ERROR: pulled digest differs: $resolved" >&2; exit 1; }
+resolved="$(docker image inspect "$IMAGE_REF" --format '{{join .RepoDigests "\n"}}')"
+grep -Eq "@sha256:${expected_digest}$" <<<"$resolved" || { echo "ERROR: pulled digest differs: $resolved" >&2; exit 1; }
 
 cosign verify --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
   --certificate-oidc-issuer "$COSIGN_ISSUER" "$IMAGE_REF" >/dev/null

--- a/scripts/security-release-container-acceptance.sh
+++ b/scripts/security-release-container-acceptance.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Final MLX-90 acceptance. Never invoke with a mutable tag.
+set -euo pipefail
+
+: "${IMAGE_REF:?IMAGE_REF must include an immutable @sha256 digest}"
+: "${EXPECTED_COLLECTION:?EXPECTED_COLLECTION is required}"
+: "${EXPECTED_VERSION:?EXPECTED_VERSION is required}"
+: "${ACCEPTANCE_COMMAND:?ACCEPTANCE_COMMAND is required}"
+: "${COSIGN_IDENTITY_REGEXP:?COSIGN_IDENTITY_REGEXP is required}"
+: "${COSIGN_ISSUER:?COSIGN_ISSUER is required}"
+
+case "$IMAGE_REF" in
+  *@sha256:[0-9a-f][0-9a-f]*) ;;
+  *) echo "ERROR: IMAGE_REF must be immutable" >&2; exit 1 ;;
+esac
+
+docker pull "$IMAGE_REF"
+resolved="$(docker image inspect "$IMAGE_REF" --format '{{index .RepoDigests 0}}')"
+[ "$resolved" = "$IMAGE_REF" ] || { echo "ERROR: pulled digest differs: $resolved" >&2; exit 1; }
+
+cosign verify --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
+  --certificate-oidc-issuer "$COSIGN_ISSUER" "$IMAGE_REF" >/dev/null
+cosign verify-attestation --type cyclonedx \
+  --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
+  --certificate-oidc-issuer "$COSIGN_ISSUER" "$IMAGE_REF" >/dev/null
+cosign verify-attestation --type slsaprovenance \
+  --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
+  --certificate-oidc-issuer "$COSIGN_ISSUER" "$IMAGE_REF" >/dev/null
+
+installed="$(docker run --rm "$IMAGE_REF" ansible-galaxy collection list "$EXPECTED_COLLECTION" --format json)"
+python3 - "$EXPECTED_COLLECTION" "$EXPECTED_VERSION" "$installed" <<'PY'
+import json, sys
+collection, expected, raw = sys.argv[1:]
+payload = json.loads(raw)
+versions = [data[collection]["version"] for data in payload.values() if collection in data]
+if versions != [expected]:
+    raise SystemExit(f"installed {collection} versions {versions!r}, expected exactly {expected!r}")
+PY
+
+docker run --rm "$IMAGE_REF" bash -euo pipefail -c "$ACCEPTANCE_COMMAND"
+printf '%s\n' "MLX-90 final acceptance passed for $IMAGE_REF"


### PR DESCRIPTION
Implements #490: patch releases for chore(deps)/fix(security) and immutable-digest final acceptance covering pull, Collection version, security acceptance, signature, SBOM and provenance. Validation: shell syntax, release config JSON and git diff check.