### PR TITLE
fix: harden MLX-90 release finalizer inputs

### DIFF
--- a/.github/workflows/security-release-finalize.yml
+++ b/.github/workflows/security-release-finalize.yml
@@ -1,0 +1,48 @@
+# MLX-90 finalizer. Dispatch is restricted to the trusted release App by repository policy.
+# yamllint disable rule:truthy rule:line-length
+---
+name: Security release final acceptance
+on:
+  repository_dispatch:
+    types: [security-release-finalize]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  verify-published-digest:
+    name: Pull and verify published container digest
+    runs-on: ubuntu-latest
+    environment: security-release-acceptance
+    steps:
+      - name: Validate immutable consumer merge SHA
+        shell: bash
+        env:
+          CONSUMER_MERGE_SHA: ${{ github.event.client_payload.consumer_merge_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$CONSUMER_MERGE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::consumer_merge_sha must be a full immutable SHA"
+            exit 1
+          }
+
+      - name: Checkout accepted main revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ github.event.client_payload.consumer_merge_sha }}
+          persist-credentials: false
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Verify immutable release and fix acceptance
+        shell: bash
+        env:
+          IMAGE_REF: ${{ github.event.client_payload.image_ref }}
+          EXPECTED_COLLECTION: ${{ github.event.client_payload.collection }}
+          EXPECTED_VERSION: ${{ github.event.client_payload.collection_version }}
+          ACCEPTANCE_COMMAND: ${{ vars.MLX90_ACCEPTANCE_COMMAND }}
+          COSIGN_IDENTITY_REGEXP: ${{ vars.MLX90_COSIGN_IDENTITY_REGEXP }}
+          COSIGN_ISSUER: ${{ vars.MLX90_COSIGN_ISSUER }}
+        run: scripts/security-release-container-acceptance.sh

--- a/scripts/security-release-container-acceptance.sh
+++ b/scripts/security-release-container-acceptance.sh
@@ -25,15 +25,18 @@ cosign verify-attestation --type slsaprovenance \
   --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
   --certificate-oidc-issuer "$COSIGN_ISSUER" "$IMAGE_REF" >/dev/null
 
-installed="$(docker run --rm "$IMAGE_REF" ansible-galaxy collection list "$EXPECTED_COLLECTION" --format json)"
-python3 - "$EXPECTED_COLLECTION" "$EXPECTED_VERSION" "$installed" <<'PY'
+docker run --rm "$IMAGE_REF" ansible-galaxy collection list "$EXPECTED_COLLECTION" --format json |
+python3 -c '
 import json, sys
-collection, expected, raw = sys.argv[1:]
-payload = json.loads(raw)
-versions = [data[collection]["version"] for data in payload.values() if collection in data]
+collection, expected = sys.argv[1:]
+try:
+    payload = json.load(sys.stdin)
+    versions = [data[collection]["version"] for data in payload.values() if collection in data]
+except (json.JSONDecodeError, KeyError, TypeError) as exc:
+    raise SystemExit(f"invalid ansible-galaxy collection output: {exc}") from exc
 if versions != [expected]:
     raise SystemExit(f"installed {collection} versions {versions!r}, expected exactly {expected!r}")
-PY
+' "$EXPECTED_COLLECTION" "$EXPECTED_VERSION"
 
 docker run --rm "$IMAGE_REF" bash -euo pipefail -c "$ACCEPTANCE_COMMAND"
 printf '%s\n' "MLX-90 final acceptance passed for $IMAGE_REF"

--- a/scripts/security-release-container-acceptance.sh
+++ b/scripts/security-release-container-acceptance.sh
@@ -31,6 +31,8 @@ import json, sys
 collection, expected = sys.argv[1:]
 try:
     payload = json.load(sys.stdin)
+    if not isinstance(payload, dict):
+        raise TypeError("top-level value must be an object")
     versions = [data[collection]["version"] for data in payload.values() if collection in data]
 except (json.JSONDecodeError, KeyError, TypeError) as exc:
     raise SystemExit(f"invalid ansible-galaxy collection output: {exc}") from exc


### PR DESCRIPTION
Addresses all actionable findings from promotion PR #492: validate the immutable merge SHA and stream defensive collection JSON parsing.