### PR TITLE
fix(release): restrict MLX-90 finalizer sender

### DIFF
--- a/.github/workflows/security-release-finalize.yml
+++ b/.github/workflows/security-release-finalize.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   verify-published-digest:
+    if: github.event.sender.login == 'lightning-it-release-automation[bot]'
     name: Pull and verify published container digest
     runs-on: ubuntu-latest
     environment: security-release-acceptance

--- a/.github/workflows/security-release-finalize.yml
+++ b/.github/workflows/security-release-finalize.yml
@@ -8,14 +8,29 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
+  validate-dispatch-sender:
+    name: Reject untrusted dispatch senders
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require trusted release automation App
+        env:
+          DISPATCH_SENDER: ${{ github.event.sender.login }}
+        run: |
+          if [[ "$DISPATCH_SENDER" != 'lightning-it-release-automation[bot]' ]]; then
+            echo "::error::Untrusted repository_dispatch sender: $DISPATCH_SENDER"
+            exit 1
+          fi
+
   verify-published-digest:
-    if: github.event.sender.login == 'lightning-it-release-automation[bot]'
     name: Pull and verify published container digest
+    needs: validate-dispatch-sender
     runs-on: ubuntu-latest
     environment: security-release-acceptance
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Validate immutable consumer merge SHA
         shell: bash


### PR DESCRIPTION
Adds an in-workflow allowlist for the trusted release automation App sender so untrusted repository_dispatch events fail closed.\n\nFollow-up to #493.