### PR TITLE
fix(release): reissue immutable MLX-90 evidence

### DIFF
--- a/docs/mlx90-immutable-release-reissue.md
+++ b/docs/mlx90-immutable-release-reissue.md
@@ -1,0 +1,15 @@
+# MLX-90 immutable release reissue
+
+The `v1.24.1` release was published before GitHub Release Immutability was
+enabled for this repository. GitHub does not apply that setting retroactively,
+so the published release remains mutable and cannot satisfy the MLX-90 final
+acceptance contract.
+
+The next patch release is therefore the first eligible immutable MLX-90
+container release. It must be created by the normal `develop` to `main`
+promotion and App-authenticated semantic-release path. The release workflow
+must verify the repository setting before mutation and the concrete release's
+immutable state before tag promotion or downstream finalization.
+
+`v1.24.1` remains available as historical evidence, but it is explicitly not
+the immutable final-acceptance release.


### PR DESCRIPTION
## Summary

- records that v1.24.1 predates repository immutable-release enforcement and remains historical evidence only
- triggers the normal protected promotion and semantic-release path for v1.24.2
- preserves the existing MLX-90 release/final-acceptance implementation without rewriting the old release

## Verification

- canonical container CI profile: PASS
- semantic-release dry-run: v1.24.2
- history-free external review: PUSH_READY PASS
- exact reviewed head: 0d6d7e66780534fe07f3a90e1ac5347791eb8e0e

Merge only after all protected Current-Head gates pass; no branch, ruleset, or administrator bypass.